### PR TITLE
Update implementations.html

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -94,7 +94,7 @@
       <p><a href="https://github.com/hozn/coilmq/">CoilMQ</a></p>
     </td>
     <td>a lightweight pure Python STOMP broker inspired by StompServer</td>
-    <td>1.0</td>
+    <td>1.0 1.1 1.2</td>
   </tr>
   <tr>
     <td>


### PR DESCRIPTION
CoilMQ now supports 1.1 and 1.2 versions of the STOMP
